### PR TITLE
Making zts prefetch timer thread a daemon thread

### DIFF
--- a/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -3067,7 +3067,7 @@ public class ZTSClient implements Closeable {
 
         synchronized (TIMER_LOCK) {
             if (FETCH_TIMER == null) {
-                FETCH_TIMER = new Timer();
+                FETCH_TIMER = new Timer(true);
                 // check the fetch items every prefetchInterval seconds.
                 FETCH_TIMER.schedule(new TokenPrefetchTask(), 0, prefetchInterval * 1000);
             }


### PR DESCRIPTION
**Overview:**

- ZTS client currently prefetches role tokens by default.
- Role token prefetches are executed on a timer thread
- Prefetching starts after first call to `prefetchToken` 
- On JVM shutdown, applications may appear to hang waiting on prefetch timer task to complete.
- Library clients need to call `ZTSClient.cancelPrefetch();` to explicitly stop the prefetch task and allow JVM clean shutdown

**Issue:**

It is not obvious to library users when the prefetch timer task starts or that the task must be explicitly cancelled.

**Update:**

This update makes the prefetch timer task a daemon thread to allow clean JVM shutdown **without** explicitly having to call `ZTSClient.cancelPrefetch();`
